### PR TITLE
index changes

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.4.1">>},0}]}.
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.4.2">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"F87D6B3378D15DFC27DE578EB6B5BCA41685B26C47189457F107321C5AE843FC">>}]}
+ {<<"lager">>, <<"150B9A17B23AE6D3265CC10DC360747621CF217B7A22B8CDDF03B2909DBF7AA5">>}]}
 ].

--- a/src/vrrm.erl
+++ b/src/vrrm.erl
@@ -1,7 +1,9 @@
 -module(vrrm).
 
 %% API exports
--export([config/1]).
+-export([
+         config/1, config/2
+        ]).
 
 %%====================================================================
 %% API functions
@@ -10,6 +12,9 @@
 config(Key) ->
     {ok, Val} = application:get_env(vrrm, Key),
     Val.
+
+config(Key, Default) ->
+    application:get_env(vrrm, Key, Default).
 
 %%====================================================================
 %% Internal functions

--- a/src/vrrm_app.erl
+++ b/src/vrrm_app.erl
@@ -11,7 +11,7 @@
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    lager:start(),
+    %%{ok, _} = application:ensure_all_started(lager),
     vrrm_sup:start_link().
 
 stop(_State) ->

--- a/src/vrrm_cli.erl
+++ b/src/vrrm_cli.erl
@@ -67,7 +67,7 @@ request(Replica, Request, Client) when is_atom(Replica) ->
     request(whereis(Replica), Request, Client);
 request(Replica, Request,
         #cli{config = []} = Client) ->
-    Config = vrrm_replica:get_config(Replica),
+    {ok, Config} = vrrm_replica:get_config(Replica),
     request(Replica, Request, Client#cli{config = Config});
 request(Replica, Request,
         #cli{request = Next, epoch = Epoch,
@@ -123,14 +123,13 @@ reconfigure(Replica, Request) when is_pid(Replica) ->
         {ok, Reply, Cli1} ->
             put('$vrrm_cli_state', Cli1),
             {ok, Reply};
-        {error, Reason, Cli1} ->
-            put('$vrrm_cli_state', Cli1),
-            {error, Reason}
+        E ->
+            E % pass errors straight through
     end.
 
 reconfigure(Replica, Request,
         #cli{config = []} = Client) ->
-    Config = vrrm_replica:get_config(Replica),
+    {ok, Config} = vrrm_replica:get_config(Replica),
     reconfigure(Replica, Request, Client#cli{config = Config});
 reconfigure(Replica, Request,
             #cli{request = Next, epoch = Epoch,

--- a/src/vrrm_manager.erl
+++ b/src/vrrm_manager.erl
@@ -89,11 +89,11 @@ handle_call({start_quorum, Name, Mod, ModArgs, RequestedNodes}, _From,
             {ok, Pid} = vrrm_replica:start_link(Mod, ModArgs, true, #{}),
             QuorumNodes = [Pid | QuorumNodes0],
             lager:info("quorum nodes: ~p", [QuorumNodes]),
+            vrrm_replica:initial_config(Pid, QuorumNodes),
             [gen_server:call({?SERVER, Node},
                              {config_quorum, Name, QuorumNodes},
                              ReplyWait)
              || Node <- FilteredList],
-            vrrm_replica:initial_config(Pid, QuorumNodes),
             Q2 = Quora#{Name => #{mod => Mod,
                                   mod_args => ModArgs,
                                   pid => Pid,
@@ -128,7 +128,7 @@ handle_call({quorum_status, Name}, _From,
                         lager:info("primary? ~p", [Primary]),
                         {ok, Status} = vrrm_replica:get_status(Primary),
                         Status;
-                    L when is_list(L) ->
+                    {ok, L} when is_list(L) ->
                         {ok, Status} = vrrm_replica:get_status(Pid),
                         Status
                 end,

--- a/test/config/sys.config
+++ b/test/config/sys.config
@@ -5,11 +5,12 @@
    {manager_update_interval, 100}
   ]},
 {lager, [{handlers, [{lager_console_backend,
-                      [debug, {lager_default_formatter, [date, " ", time, " ", color, "[", severity, "] ",
-                                                         {pid, ["pid=", pid], ""},
-                                                         {module, [
-                                                                  " module=", module, " ",
-                                                                  {function, ["function=", function, " "], ""},
-                                                                  {line, ["line=",line], ""}], ""},
-                                                         " ", message, "\n"]}]}]}]}
+                      [info,
+                       {lager_default_formatter, [date, " ", time, " ", color, "[", severity, "] ",
+                                                  {pid, ["pid=", pid], ""},
+                                                  {module, [
+                                                            "", module, ":",
+                                                            {function, [function, ":"], ""},
+                                                            {line, [line], ""}], ""},
+                                                  " ", message, "\n"]}]}]}]}
 ].


### PR DESCRIPTION
This still leaves things quite messy, but fast moving codebases, etc.

fixes #2 
fixes #7 
fixes #9

Changes detailed below:

- move to doing primary selection correctly, discarding the old,
  clumsy approach that required mutating the config list all the time,
  and did not accord with the protocol anyway.

- but in order to debug the issues that doing so casued, I was forced
  to conflate the move to gen_statem, because it's a lot easier to
  debug, so that is also here

- lastly, I added a limit to the number of old entries per client, in
  order to control memory bloat.

- at this commit we're still logging quite a lot.  At some point I'll
  pull back on that, and even remove some debug logging, but right now
  as we're expecting a few bugs to crawl out of the woodwork, it's
  better to leave it all in in order to make it easier to find issues.