### PR TITLE
optimize view change

### DIFF
--- a/src/vrrm.app.src
+++ b/src/vrrm.app.src
@@ -21,7 +21,7 @@
     {primary_failure_interval, 4000}, % 4 seconds
     %% how many ops do we commit before we update the snapshot and
     %% compact the log
-    {snapshot_op_interval, 100}
+    {snapshot_op_interval, 2000}
    ]},
   {modules, []}
  ]}.


### PR DESCRIPTION
Establish and maintain a global minimum frontier for the lowest committed operation in the cluster, allowing various optimizations.  The only optimization included in this PR is shipping a log tail instead of the entire log during view changes.